### PR TITLE
CMR-6267

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -15,6 +15,8 @@ gem 'responders', '~> 2.0'
 gem 'loofah', '>= 2.3.1'
 gem 'rack', '~> 1.6.11'
 gem 'rake', '12.3.3'
+gem 'sprockets', '3.7.2'
+gem 'sass', '3.7.4'
 
 group :assets do
   gem 'sass-rails'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -137,6 +137,9 @@ GEM
       thor (>= 0.18.1, < 2.0)
     raindrops (0.19.1)
     rake (12.3.3)
+    rb-fsevent (0.10.3)
+    rb-inotify (0.10.1)
+      ffi (~> 1.0)
     ref (2.0.0)
     regexp_parser (1.7.0)
     responders (2.4.1)
@@ -155,7 +158,7 @@ GEM
     rspec-mocks (3.9.1)
       diff-lcs (>= 1.2.0, < 2.0)
       rspec-support (~> 3.9.0)
-    rspec-rails (3.9.0)
+    rspec-rails (3.9.1)
       actionpack (>= 3.0)
       activesupport (>= 3.0)
       railties (>= 3.0)
@@ -168,6 +171,11 @@ GEM
       rspec-core (>= 2, < 4, != 2.12.0)
     ruby-prof (1.3.0)
     safe_yaml (1.0.5)
+    sass (3.7.4)
+      sass-listen (~> 4.0.0)
+    sass-listen (4.0.0)
+      rb-fsevent (~> 0.9, >= 0.9.4)
+      rb-inotify (~> 0.9, >= 0.9.7)
     sass-rails (6.0.0)
       sassc-rails (~> 2.1, >= 2.1.1)
     sassc (2.2.1)
@@ -178,7 +186,7 @@ GEM
       sprockets (> 3.0)
       sprockets-rails
       tilt
-    sprockets (4.0.0)
+    sprockets (3.7.2)
       concurrent-ruby (~> 1.0)
       rack (> 1, < 3)
     sprockets-rails (3.2.1)
@@ -202,7 +210,7 @@ GEM
       kgio (~> 2.6)
       raindrops (~> 0.7)
     vcr (5.1.0)
-    webmock (3.8.2)
+    webmock (3.8.3)
       addressable (>= 2.3.6)
       crack (>= 0.3.2)
       hashdiff (>= 0.4.0, < 2.0.0)
@@ -234,7 +242,9 @@ DEPENDENCIES
   rspec-rails
   rspec_junit_formatter
   ruby-prof
+  sass (= 3.7.4)
   sass-rails
+  sprockets (= 3.7.2)
   therubyracer
   uglifier
   unicorn


### PR DESCRIPTION
Removing sprockets broke deployments but passed build stage, this fixes the deployment